### PR TITLE
Fix URL in presence.py to point to the correct riitag.t0g3pii.de user page

### DIFF
--- a/riitag/presence.py
+++ b/riitag/presence.py
@@ -28,7 +28,7 @@ def format_presence(riitag_info: RiitagInfo):
         'small_text': 'riitag.t0g3pii.de',
 
         'buttons': [
-            {'label': 'View RiiTag', 'url': f'https://tag.rc24.xyz/user/{riitag_info.id}'}
+            {'label': 'View RiiTag', 'url': f'https://riitag.t0g3pii.de/user/{riitag_info.id}'}
         ]
     }
 


### PR DESCRIPTION
Fixed the _View RiiTag_ button, now it actually points to the correct RiiTag user page